### PR TITLE
Activate each_with_object

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -7,6 +7,7 @@ MRuby::Gem::Specification.new('mruby-system-stats') do |spec|
   spec.add_dependency 'mruby-sysconf'
   spec.add_dependency 'mruby-onig-regexp'
   spec.add_dependency 'mruby-thread'
+  spec.add_dependency 'mruby-enum-ext'
   spec.add_test_dependency 'mruby-sprintf'
   spec.cc.flags << "-DMRB_THREAD_COPY_VALUES"
 end


### PR DESCRIPTION
Tests are failing now:

```
NoMethodError: Stats::Memory.current => undefined method 'each_with_object' for #<Array:0x26615e0> (mrbgems: mruby-system-stats)
NoMethodError: Stats::Disk.current => undefined method 'each_with_object' for #<Array:0x265e580> (mrbgems: mruby-system-stats)
Skip: GC in rescue  backtrace isn't available
Skip: Method call in rescue  backtrace isn't available
Skip: Module#prepend super in alias  super does not currently work in aliased methods
Total: 1123
   OK: 1121
   KO: 0
Crash: 2
 Time: 2.2 seconds
```

`each_with_object` is defined `mruby-enum-ext` core mgem.